### PR TITLE
Add shutdown_node tracepoint event

### DIFF
--- a/include/tracetools/tracetools.h
+++ b/include/tracetools/tracetools.h
@@ -42,6 +42,8 @@ void task_init(const char *task_name, const char *owner = NULL);
 /// also set's procname, but be aware that's limited to 16 chars
 void node_init(const char *node_name, unsigned int roscpp_version);
 
+void node_shutdown(const char *node_name);
+
 void timer_added(const void *fun_ptr, const char *type_info, int period_sec,
                  int period_nsec);
 /**

--- a/lttng/tp_call.tp
+++ b/lttng/tp_call.tp
@@ -11,7 +11,17 @@ TRACEPOINT_EVENT(
 		ctf_string(node_name, node_name_arg)
 		ctf_integer(int, roscpp_version_compiletime, roscpp_version_arg)
 	)
-)		
+)
+TRACEPOINT_EVENT(
+	roscpp,
+	shutdown_node,
+	TP_ARGS(
+		const char*, node_name_arg
+	),
+	TP_FIELDS(
+		ctf_string(node_name, node_name_arg)
+	)
+)
 TRACEPOINT_EVENT(
     roscpp,
     new_connection,

--- a/scripts/setup-lttng-roscpp.sh
+++ b/scripts/setup-lttng-roscpp.sh
@@ -12,7 +12,8 @@ for event in roscpp:new_connection roscpp:callback_added roscpp:timer_added\
 	roscpp:subscriber_callback_start roscpp:subscriber_callback_end\
 	roscpp:publisher_message_queued	roscpp:subscriber_link_message_write\
 	roscpp:subscriber_link_message_drop roscpp:subscriber_callback_added\
-	roscpp:subscriber_callback_wrapper roscpp:task_start roscpp:init_node\
+	roscpp:subscriber_callback_wrapper roscpp:task_start\
+	roscpp:init_node roscpp:shutdown_node\
 	nodelet:task_start nodelet:init tf2:task_start roscpp:message_processed\
 	roscpp:trace_link roscpp:ptr_name_info roscpp:ptr_call roscpp:timer_scheduled
 do

--- a/src/tracetools/tracetools.cpp
+++ b/src/tracetools/tracetools.cpp
@@ -64,6 +64,11 @@ void node_init(const char* node_name, unsigned int roscpp_version) {
 	prctl(PR_SET_NAME, node_name, NULL, NULL, NULL);
 #endif
 }
+void node_shutdown(const char* node_name) {
+#ifdef WITH_LTTNG
+	tracepoint(roscpp, shutdown_node, node_name);
+#endif
+}
 void call_start(const void* ptr_ref, const void* data,
 		const uint64_t trace_id) {
 #ifdef WITH_LTTNG


### PR DESCRIPTION
This adds a shutdown_node event to complement the init_node event and allow the trace data to reflect the node's actual lifetime.